### PR TITLE
修复 #130 ，对于汇编函数使用.def文件导出符号；其他杂项改动

### DIFF
--- a/example/lammp/example1.cpp
+++ b/example/lammp/example1.cpp
@@ -28,7 +28,7 @@ int main() {
     mp_ptr c = (mp_ptr)lmmp_alloc(len * sizeof(mp_limb_t));
     auto start = std::chrono::high_resolution_clock::now();
     // 调用不平衡乘法算子
-    lmmp_mul_(c, a, len1, b, len2);
+    lmmp_mul_(c, b, len2, a, len1);
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
     std::cout << "multiplication time: " << duration.count() << " microseconds" << std::endl;

--- a/include/lammp/lmmp.h
+++ b/include/lammp/lmmp.h
@@ -80,36 +80,26 @@ extern "C" {
  1. heap_alloc : 堆内存分配器
  2. heap_free : 堆内存释放器
  3. realloc : 堆内存重新分配器
- 4. set_stack_allocator : 设置自定义栈分配器
 
- 前三个函数默认使用 malloc、free、realloc 实现，
- 而默认栈实现为：
-  首次调用时分配一块大小为LAMMP_DEFAULT_STACK_SIZE的堆内存
-  （通过调用 heap_alloc 函数），通过维护此堆内存来模拟栈。
-  同时请注意，我们默认栈是向上增长的，即从低地址到高地址。
- 
- 如果使用自定义栈，请进行手动内存管理和处理溢出。默认栈是全局的，
- 同时默认栈的大小是可调的，可以通过函数 lmmp_default_stack_reset 来调整
+ 默认使用 malloc、free、realloc 实现。
  */
 
 typedef void* (*lmmp_heap_alloc_fn)(size_t size);
-typedef void (*lmmp_heap_free_fn)(void* ptr);
-typedef void* (*lmmp_realloc_fn)(void* ptr, size_t size);
-typedef void* (*lmmp_stack_get_top_fn)(void);
-typedef void (*lmmp_stack_set_top_fn)(void* top);
+typedef void  (*lmmp_heap_free_fn )(void*  ptr);
+typedef void* (*lmmp_realloc_fn   )(void*  ptr, size_t size);
 
 typedef struct {
-    lmmp_heap_alloc_fn alloc;
-    lmmp_heap_free_fn free;
-    lmmp_realloc_fn realloc;
+    lmmp_heap_alloc_fn   alloc;
+    lmmp_heap_free_fn     free;
+    lmmp_realloc_fn    realloc;
 } lmmp_heap_allocator_t;
 
 /**
  * @brief 设置 LAMMP 全局堆内存分配函数
- * @param heap 新的堆内存分配器，可以为NULL，表示使用默认的 malloc
+ * @param heap 新的堆内存分配器，可以为NULL，表示使用默认的 malloc, free, realloc
  * @warning 由于所有共享内存都采用堆内存分配。因此，传入新的堆分配器将会首先调用
  *          lmmp_global_deinit 函数，释放所有共享内存，以保证老旧的堆资源被释放。
- *          然后将会自动调用 lmmp_global_init 函数。
+ *          然后将会自动调用 lmmp_global_init 函数，重新分配所有线程局部内存。
  *          同时，为保证内存不泄露，在开启 LAMMP_DEBUG_MEMORY_LEAK 宏时，将会对堆
  *          栈分配器进行检查。若此时堆栈分配计数器不为 0，则会触发lmmp_abort函数，
  *          并输出相应的错误信息。
@@ -118,9 +108,9 @@ typedef struct {
 LAMMP_API void lmmp_set_heap_allocator(const lmmp_heap_allocator_t* heap);
 
 /**
- * @brief LAMMP 全局栈重置函数
- * @param size 新的默认栈大小，单位为字节（不建议设置少于 256KB 的栈）
- * @warning 请注意调用此函数后，访问之前的分配的栈空间将会导致未定义行为。在定义了 
+ * @brief LAMMP 全局栈重置函数（通常不需要手动调用）
+ * @param size 新的默认栈大小，单位为字节（不建议设置少于 256KB 的栈，少于此值可能导致栈溢出）
+ * @warning 请注意调用此函数后，访问之前的分配的栈空间将会导致未定义行为。在定义了
  *          LAMMP_DEBUG_MEMORY_LEAK 宏时，释放默认栈时，会检查默认栈是否为空，
  *          若默认栈不为空，则会触发lmmp_abort函数。栈为空时，或者无法确定栈是否初始化，
  *          均可以调用此函数，如果设置的大小比此前的大小小，则会直接重置栈顶，否则，会重新分
@@ -132,8 +122,9 @@ LAMMP_API void lmmp_set_heap_allocator(const lmmp_heap_allocator_t* heap);
 LAMMP_API void lmmp_stack_reset(size_t size);
 
 /**
- * @brief LAMMP 全局栈初始化函数
- * @note 按照默认的栈大小，对栈进行初始化，若栈已经初始化，则不进行任何操作。
+ * @brief LAMMP 全局栈初始化函数（通常不需要手动调用）
+ * @note 按照默认的栈大小（320kb），对栈进行初始化，可多次重入。
+ *       lmmp_global_init 函数会自动调用此函数，无需手动调用。
  */
 LAMMP_API void lmmp_stack_init(void);
 
@@ -409,6 +400,7 @@ LAMMP_API void lmmp_stack_free(void* ptr);
  * @brief 全局初始化函数（线程局部的）
  * @note 调用此函数将初始化全局范围内的所有线程局部资源，如栈式分配器等。
  *       部分惰性初始化的资源将在首次使用时初始化。调用此函数不会进行初始化。
+ *       此函数可重入，多次调用不会导致重复初始化。
  * @warning 我们建议在进程或线程启动时调用此函数，以保证线程安全。
  */
 LAMMP_API void lmmp_global_init(void);
@@ -416,8 +408,7 @@ LAMMP_API void lmmp_global_init(void);
 /**
  * @brief （线程局部的）全局共享的动态分配的堆内存资源释放函数
  * @note 调用此函数将释放全局范围内的所有动态分配的堆内存资源。
- *       释放后，部分资源采用惰性初始化，如再次调用，则将会在后
- *       续调用中重新分配堆内存并初始化。
+ *       此函数可重入，多次调用不会导致重复释放。如需要再次使用，请重新调用 lmmp_global_init 初始化。
  * @warning 我们建议在线程结束时或程序进程结束时调用此函数。多线程下，每个线程都会拥有独立的副本，
  *          未调用此函数结束线程可能导致内存泄漏。
  */

--- a/src/lammp/CMakeLists.txt
+++ b/src/lammp/CMakeLists.txt
@@ -8,7 +8,14 @@ file(GLOB_RECURSE LAMMP_CORE_SRCS
 )
 
 if(USE_ASM AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-
+    
+    # 启用汇编时，需要使用.def文件导出汇编实现的函数
+    # 未启用时，纯c实现的函数会自动导出 
+    set(DEF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/asm/lammp_asm.def)
+    if(TARGET_SYSTEM STREQUAL "WIN")
+        list(APPEND LAMMP_CORE_SRCS ${DEF_FILE})
+    endif()
+    # 过滤掉 generic 目录下的源文件
     list(FILTER LAMMP_CORE_SRCS EXCLUDE REGEX ".*/generic/.*")
 
     # 收集汇编文件

--- a/src/lammp/asm/lammp_asm.def
+++ b/src/lammp/asm/lammp_asm.def
@@ -1,0 +1,48 @@
+LIBRARY LammpCore
+EXPORTS
+    lmmp_mul_1_
+    lmmp_mul_basecase_
+    lmmp_sqr_basecase_
+
+    lmmp_not_
+    lmmp_shlnot_
+
+    lmmp_shl_
+    lmmp_shl_c_
+    lmmp_shr_
+    lmmp_shr_c_
+
+    lmmp_add_n_
+    lmmp_add_nc_
+    lmmp_sub_n_
+    lmmp_sub_nc_
+
+    lmmp_addmul_1_
+    lmmp_submul_1_
+
+    lmmp_addshl1_n_
+    lmmp_subshl1_n_
+    
+    lmmp_shr1add_n_
+    lmmp_shr1add_nc_
+    lmmp_shr1sub_n_
+    lmmp_shr1sub_nc_
+
+    lmmp_div_1_
+    lmmp_div_1_s_
+    lmmp_div_2_
+    lmmp_div_2_s_
+    lmmp_div_3_2_
+    lmmp_mod_1_
+    lmmp_mod_2_
+
+    lmmp_inv_1_
+    lmmp_inv_2_1_
+
+    lmmp_limb_bits_
+    lmmp_leading_zeros_
+    lmmp_tailing_zeros_
+    lmmp_limb_popcnt_
+    lmmp_mulh_
+    lmmp_mullh_
+    lmmp_mulmod_ulong_

--- a/src/lammp/asm/x64/add_n_c.asm
+++ b/src/lammp/asm/x64/add_n_c.asm
@@ -12,11 +12,6 @@ default rel
 
 %define ADCSBB adc
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_add_n_"
-    db " -export:lmmp_add_nc_"
-%endif
 
 section .text
 align 16

--- a/src/lammp/asm/x64/addmul_1.asm
+++ b/src/lammp/asm/x64/addmul_1.asm
@@ -4,10 +4,8 @@
 ;
 ; lmmp_addmul_1_ : [numa, n] += [numb, n] * b
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_addmul_1_"
-%endif
+bits 64
+default rel
 
 section .text
 global lmmp_addmul_1_

--- a/src/lammp/asm/x64/addshl1_n.asm
+++ b/src/lammp/asm/x64/addshl1_n.asm
@@ -7,10 +7,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_addshl1_n_"
-%endif
 
 section .text
 align 16

--- a/src/lammp/asm/x64/div_1.asm
+++ b/src/lammp/asm/x64/div_1.asm
@@ -10,12 +10,6 @@ bits 64
 default rel
 
 %ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_div_1_"
-    db " -export:lmmp_div_1_s_"
-%endif
-
-%ifdef LAMMP_ASM_WIN
   %define win
   %define lin ;
   %define rx0 rcx

--- a/src/lammp/asm/x64/div_2.asm
+++ b/src/lammp/asm/x64/div_2.asm
@@ -9,11 +9,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_div_2_"
-    db " -export:lmmp_div_2_s_"
-%endif
 
 %ifdef LAMMP_ASM_WIN
   %define win

--- a/src/lammp/asm/x64/div_3_2.asm
+++ b/src/lammp/asm/x64/div_3_2.asm
@@ -7,11 +7,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_div_3_2_"
-%endif
-
 section .text
 align 16
 

--- a/src/lammp/asm/x64/inv_1.asm
+++ b/src/lammp/asm/x64/inv_1.asm
@@ -9,11 +9,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_inv_1_"
-    db " -export:lmmp_inv_2_1_"
-%endif
 
 section .text
 global lmmp_inv_1_

--- a/src/lammp/asm/x64/mod_1.asm
+++ b/src/lammp/asm/x64/mod_1.asm
@@ -7,10 +7,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_mod_1_"
-%endif
 
 %ifdef LAMMP_ASM_WIN
   %define win

--- a/src/lammp/asm/x64/mod_2.asm
+++ b/src/lammp/asm/x64/mod_2.asm
@@ -9,11 +9,6 @@ default rel
 
 
 %ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_mod_2_"
-%endif
-
-%ifdef LAMMP_ASM_WIN
   %define win
   %define lin ;
   %define rx0 rcx

--- a/src/lammp/asm/x64/mul_1.asm
+++ b/src/lammp/asm/x64/mul_1.asm
@@ -8,10 +8,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_mul_1_"
-%endif
 
 section .text
 global lmmp_mul_1_

--- a/src/lammp/asm/x64/mul_basecase.asm
+++ b/src/lammp/asm/x64/mul_basecase.asm
@@ -6,10 +6,6 @@
 ; void lmmp_mul_basecase_(mp_ptr dst, mp_srcptr numa, mp_size_t na, mp_srcptr numb, mp_size_t nb);
 
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_mul_basecase_"
-%endif
 
 %ifdef LAMMP_ASM_WIN
     ; Windows: dst=rcx, numa=rdx, na=r8, numb=r9, nb=[rsp+48h]

--- a/src/lammp/asm/x64/not.asm
+++ b/src/lammp/asm/x64/not.asm
@@ -7,10 +7,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_not_"
-%endif
 
 %ifdef LAMMP_ASM_WIN
  %macro PROLOG 0

--- a/src/lammp/asm/x64/shl.asm
+++ b/src/lammp/asm/x64/shl.asm
@@ -9,11 +9,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_shl_"
-    db " -export:lmmp_shl_c_"
-%endif
 
 section .text
 align 16

--- a/src/lammp/asm/x64/shlnot.asm
+++ b/src/lammp/asm/x64/shlnot.asm
@@ -7,11 +7,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_shlnot_"
-%endif
-
 %macro win64_args 0
 %ifdef LAMMP_ASM_WIN
     xchg rcx,r9

--- a/src/lammp/asm/x64/shr.asm
+++ b/src/lammp/asm/x64/shr.asm
@@ -9,12 +9,6 @@
 bits 64
 default rel
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_shr_"
-    db " -export:lmmp_shr_c_"
-%endif
-
 section .text
 align 16
 

--- a/src/lammp/asm/x64/shr1add_n_c.asm
+++ b/src/lammp/asm/x64/shr1add_n_c.asm
@@ -7,11 +7,8 @@
 ; mp_limb_t lmmp_shr1add_nc_(mp_ptr dst, mp_srcptr numa, mp_srcptr numb, mp_size_t n, mp_limb_t c);
 
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_shr1add_n_"
-    db " -export:lmmp_shr1add_nc_"
-%endif
+bits 64
+default rel
 
 %ifdef LAMMP_ASM_WIN
  %macro WIN_PROLOG 0

--- a/src/lammp/asm/x64/shr1sub_n_c.asm
+++ b/src/lammp/asm/x64/shr1sub_n_c.asm
@@ -7,11 +7,8 @@
 ; mp_limb_t lmmp_shr1sub_nc_(mp_ptr dst, mp_srcptr numa, mp_srcptr numb, mp_size_t n, mp_limb_t c);
 
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_shr1sub_n_"
-    db " -export:lmmp_shr1sub_nc_"
-%endif
+bits 64
+default rel
 
 %ifdef LAMMP_ASM_WIN
  %macro WIN_PROLOG 0

--- a/src/lammp/asm/x64/sqr_basecase.asm
+++ b/src/lammp/asm/x64/sqr_basecase.asm
@@ -9,11 +9,6 @@ bits 64
 default rel
 
 %ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_sqr_basecase_"
-%endif
-
-%ifdef LAMMP_ASM_WIN
     ; Windows x64 : RCX=dst, RDX=numa, R8=na
     %define rx0     rcx     ; dst
     %define rx1     rdx     ; numa

--- a/src/lammp/asm/x64/sub_n_c.asm
+++ b/src/lammp/asm/x64/sub_n_c.asm
@@ -13,12 +13,6 @@ default rel
 %define ADCSBB sbb
 
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_sub_n_"
-    db " -export:lmmp_sub_nc_"
-%endif
-
 section .text
 align 16
 

--- a/src/lammp/asm/x64/submul_1.asm
+++ b/src/lammp/asm/x64/submul_1.asm
@@ -4,14 +4,12 @@
 ;
 ; lmmp_submul_1_ : [numa, n] -= [numb, n] * b
 
-
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_submul_1_"
-%endif
+bits 64
+default rel
 
 section .text
 global lmmp_submul_1_
+
 lmmp_submul_1_:
 %ifdef LAMMP_ASM_WIN
     push    rsi

--- a/src/lammp/asm/x64/subshl1_n.asm
+++ b/src/lammp/asm/x64/subshl1_n.asm
@@ -8,11 +8,6 @@ bits 64
 default rel
 
 
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_subshl1_n_"
-%endif
-
 section .text
 align 16
 

--- a/src/lammp/asm/x64/tiny.asm
+++ b/src/lammp/asm/x64/tiny.asm
@@ -2,20 +2,8 @@
 ; This file is part of lammp, under the GNU LGPL v2 license.
 ; See LICENSE in the project root for the full license text.
 
-
 bits 64
 default rel
-
-%ifdef LAMMP_ASM_WIN
-    section .drectve
-    db " -export:lmmp_limb_bits_"
-    db " -export:lmmp_leading_zeros_"
-    db " -export:lmmp_tailing_zeros_"
-    db " -export:lmmp_limb_popcnt_"
-    db " -export:lmmp_mulh_"
-    db " -export:lmmp_mullh_"
-    db " -export:lmmp_mulmod_ulong_"
-%endif
 
 %ifdef LAMMP_ASM_WIN
   %define win


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复乘法运算示例中的参数顺序错误

* **新增功能**
  * 增强 Windows 平台支持，改进 DLL 导出机制

* **文档更新**
  * 明确堆分配器配置流程与初始化/反初始化的可重入语义
  * 补充栈操作参数说明与默认大小文档

* **调整**
  * 移除自定义栈分配器接口声明，简化 API

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lamina-dev/LAMMP/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->