### PR TITLE
优化了质数筛的性能；新增了不在质数表范围的查找

### DIFF
--- a/include/lammp/impl/mparam.h
+++ b/include/lammp/impl/mparam.h
@@ -127,9 +127,9 @@
 
 
 // cache 一次处理的位图数量
-#define PRIME_CACHE_BLOCK_NUM 32
-// 一个位图中质数最多的数量（实际为31）
-#define PRIME_CACHE_BLOCK_SIZE 32
+#define PRIME_CACHE_BLOCK_NUM 64
+// cache 中质数最多可能的数量（取决于上面的PRIME_CACHE_BLOCK_NUM）
+#define PRIME_CACHE_SIZE 1028
 
 #define MP_UCHAR_MAX (0xff)
 #define MP_USHORT_MAX (0xffff)

--- a/include/lammp/impl/prime_table.h
+++ b/include/lammp/impl/prime_table.h
@@ -36,10 +36,10 @@ extern const ushort prime_short_table[PRIME_SHORT_TABLE_SIZE];
  * @brief 根据全局素数表判断一个数是否为素数
  * @param p 待判断的数
  * @warning p>1, p%2==1
- * @note 若 p 超过了当前全局素数表的范围，则会触发 debug_assert
- * @return true 素数，false 合数
+ * @note 若 p 超过了当前全局素数表的范围，则返回 -1
+ * @return 1 素数，0 合数，-1 超出质数表范围
  */
-bool lmmp_is_prime_table_(uint p);
+int lmmp_is_prime_table_(uint p);
 
 /**
  * @brief 计算小于等于 n 的素数数量
@@ -158,12 +158,10 @@ extern const lmmp_bitset_t r35711_mask_map[19];
  * @brief 校验是否能被3,5,7,11整除，能够整除则返回1，否则返回0
  */
 static inline int trial_div35711(ulong n) {
-#define MOD 1155
-    uint rem = n % MOD;
+    uint rem = n % 1155; // 1155 = 3 * 5 * 7 * 11
     uint idx = rem / LMMP_BITSET_BITS;
     uint bit = rem % LMMP_BITSET_BITS;
     return (r35711_mask_map[idx] >> bit) & 1ULL;
-#undef MOD
 }
 
 #endif  // __LAMMP_PRIME_TABLE_H__

--- a/src/lammp/global/prime_table.c
+++ b/src/lammp/global/prime_table.c
@@ -26,9 +26,9 @@ typedef struct prime_int {
 } prime_int;
 
 static LAMMP_THREAD_LOCAL prime_int global_prime_int_table = {
-    .map = NULL,
+    .map      = NULL,
     .map_size = 0,
-    .max = 0
+    .max      = 0
 };
 
 #define G global_prime_int_table
@@ -40,26 +40,90 @@ static inline uint prime_table_size(uint n) {
     return bits + 1;
 }
 
+/*
+ * 预填充表没有排除idx == 0的情况，这是为了确保210*m+1的奇数被填充
+ * 但是这会导致索引为0，也即1被错误标记，需要单独处理
+  for (int s = 0; s < 105; ++s) {
+    lmmp_bitset_t mask = 0;
+    for (int k = 0; k < 64; ++k) {
+      int idx = (s + k) % 105; // 取模周期
+      uint p = 2 * idx + 1;    // 对应的奇数
+      if (p % 3 != 0 && p % 5 != 0 && p % 7 != 0)
+        mask |= 1ULL << k;
+    }
+    wheel_mask[s] = mask;
+  }
+*/
+// 预填充表（预筛了3,5,7的倍数，以及1，和他们本身）
+static const lmmp_bitset_t wheel_mask[105] = {
+    (lmmp_bitset_t)0x916d129a64b4cb61, (lmmp_bitset_t)0x48b6894d325a65b0, (lmmp_bitset_t)0xa45b44a6992d32d8,
+    (lmmp_bitset_t)0x522da2534c96996c, (lmmp_bitset_t)0x2916d129a64b4cb6, (lmmp_bitset_t)0x948b6894d325a65b,
+    (lmmp_bitset_t)0xca45b44a6992d32d, (lmmp_bitset_t)0x6522da2534c96996, (lmmp_bitset_t)0xb2916d129a64b4cb,
+    (lmmp_bitset_t)0x5948b6894d325a65, (lmmp_bitset_t)0x2ca45b44a6992d32, (lmmp_bitset_t)0x96522da2534c9699,
+    (lmmp_bitset_t)0xcb2916d129a64b4c, (lmmp_bitset_t)0x65948b6894d325a6, (lmmp_bitset_t)0x32ca45b44a6992d3,
+    (lmmp_bitset_t)0x996522da2534c969, (lmmp_bitset_t)0x4cb2916d129a64b4, (lmmp_bitset_t)0x265948b6894d325a,
+    (lmmp_bitset_t)0x932ca45b44a6992d, (lmmp_bitset_t)0x4996522da2534c96, (lmmp_bitset_t)0xa4cb2916d129a64b,
+    (lmmp_bitset_t)0xd265948b6894d325, (lmmp_bitset_t)0x6932ca45b44a6992, (lmmp_bitset_t)0xb4996522da2534c9,
+    (lmmp_bitset_t)0x5a4cb2916d129a64, (lmmp_bitset_t)0x2d265948b6894d32, (lmmp_bitset_t)0x96932ca45b44a699,
+    (lmmp_bitset_t)0xcb4996522da2534c, (lmmp_bitset_t)0x65a4cb2916d129a6, (lmmp_bitset_t)0x32d265948b6894d3,
+    (lmmp_bitset_t)0x996932ca45b44a69, (lmmp_bitset_t)0x4cb4996522da2534, (lmmp_bitset_t)0xa65a4cb2916d129a,
+    (lmmp_bitset_t)0xd32d265948b6894d, (lmmp_bitset_t)0x6996932ca45b44a6, (lmmp_bitset_t)0xb4cb4996522da253,
+    (lmmp_bitset_t)0xda65a4cb2916d129, (lmmp_bitset_t)0x6d32d265948b6894, (lmmp_bitset_t)0x36996932ca45b44a,
+    (lmmp_bitset_t)0x1b4cb4996522da25, (lmmp_bitset_t)0xda65a4cb2916d12,  (lmmp_bitset_t)0x86d32d265948b689,
+    (lmmp_bitset_t)0xc36996932ca45b44, (lmmp_bitset_t)0x61b4cb4996522da2, (lmmp_bitset_t)0x30da65a4cb2916d1,
+    (lmmp_bitset_t)0x186d32d265948b68, (lmmp_bitset_t)0xc36996932ca45b4,  (lmmp_bitset_t)0x861b4cb4996522da,
+    (lmmp_bitset_t)0xc30da65a4cb2916d, (lmmp_bitset_t)0x6186d32d265948b6, (lmmp_bitset_t)0xb0c36996932ca45b,
+    (lmmp_bitset_t)0xd861b4cb4996522d, (lmmp_bitset_t)0x6c30da65a4cb2916, (lmmp_bitset_t)0xb6186d32d265948b,
+    (lmmp_bitset_t)0x5b0c36996932ca45, (lmmp_bitset_t)0x2d861b4cb4996522, (lmmp_bitset_t)0x96c30da65a4cb291,
+    (lmmp_bitset_t)0xcb6186d32d265948, (lmmp_bitset_t)0x65b0c36996932ca4, (lmmp_bitset_t)0x32d861b4cb499652,
+    (lmmp_bitset_t)0x996c30da65a4cb29, (lmmp_bitset_t)0x4cb6186d32d26594, (lmmp_bitset_t)0xa65b0c36996932ca,
+    (lmmp_bitset_t)0xd32d861b4cb49965, (lmmp_bitset_t)0x6996c30da65a4cb2, (lmmp_bitset_t)0xb4cb6186d32d2659,
+    (lmmp_bitset_t)0x5a65b0c36996932c, (lmmp_bitset_t)0x2d32d861b4cb4996, (lmmp_bitset_t)0x96996c30da65a4cb,
+    (lmmp_bitset_t)0x4b4cb6186d32d265, (lmmp_bitset_t)0x25a65b0c36996932, (lmmp_bitset_t)0x92d32d861b4cb499,
+    (lmmp_bitset_t)0xc96996c30da65a4c, (lmmp_bitset_t)0x64b4cb6186d32d26, (lmmp_bitset_t)0x325a65b0c3699693,
+    (lmmp_bitset_t)0x992d32d861b4cb49, (lmmp_bitset_t)0x4c96996c30da65a4, (lmmp_bitset_t)0xa64b4cb6186d32d2,
+    (lmmp_bitset_t)0xd325a65b0c369969, (lmmp_bitset_t)0x6992d32d861b4cb4, (lmmp_bitset_t)0x34c96996c30da65a,
+    (lmmp_bitset_t)0x9a64b4cb6186d32d, (lmmp_bitset_t)0x4d325a65b0c36996, (lmmp_bitset_t)0xa6992d32d861b4cb,
+    (lmmp_bitset_t)0x534c96996c30da65, (lmmp_bitset_t)0x29a64b4cb6186d32, (lmmp_bitset_t)0x94d325a65b0c3699,
+    (lmmp_bitset_t)0x4a6992d32d861b4c, (lmmp_bitset_t)0x2534c96996c30da6, (lmmp_bitset_t)0x129a64b4cb6186d3,
+    (lmmp_bitset_t)0x894d325a65b0c369, (lmmp_bitset_t)0x44a6992d32d861b4, (lmmp_bitset_t)0xa2534c96996c30da,
+    (lmmp_bitset_t)0xd129a64b4cb6186d, (lmmp_bitset_t)0x6894d325a65b0c36, (lmmp_bitset_t)0xb44a6992d32d861b,
+    (lmmp_bitset_t)0xda2534c96996c30d, (lmmp_bitset_t)0x6d129a64b4cb6186, (lmmp_bitset_t)0xb6894d325a65b0c3,
+    (lmmp_bitset_t)0x5b44a6992d32d861, (lmmp_bitset_t)0x2da2534c96996c30, (lmmp_bitset_t)0x16d129a64b4cb618,
+    (lmmp_bitset_t)0x8b6894d325a65b0c, (lmmp_bitset_t)0x45b44a6992d32d86, (lmmp_bitset_t)0x22da2534c96996c3};
+
+#define IDX(p) ((p) >> 1)
+#define set_not_prime(p, i) p[i / LMMP_BITSET_BITS] &= ~(1ULL << (i % LMMP_BITSET_BITS))
+#define set_prime(p, i) p[i / LMMP_BITSET_BITS] |= (1ULL << (i % LMMP_BITSET_BITS))
+
 void lmmp_prime_int_table_init_(uint n) {
     if (n < PRIME_SHORT_TABLE_N || G.max >= n)
         return;
-#define IDX(p) ((p) >> 1)
-#define set_not_prime(p, i) p[i / LMMP_BITSET_BITS] &= ~(1ULL << (i % LMMP_BITSET_BITS))
-
     if (G.map == NULL) {
         G.max = n;
         G.map_size = prime_table_size(n);
         lmmp_bitset_p restrict p = ALLOC_TYPE(G.map_size, lmmp_bitset_t);
-        for (uint i = 0; i < G.map_size; ++i) {
-            p[i] = LMMP_BITSET_MASK;
+
+        // 按 105 周期填充
+        for (uint i = 0, s = 0; i < G.map_size; ++i) {
+            p[i] = wheel_mask[s];
+            // s = (s + 64) % 105;
+            s += LMMP_BITSET_BITS;
+            if (s >= 105)
+                s -= 105;
         }
+
         set_not_prime(p, 0);
+        set_prime(p, IDX(3));
+        set_prime(p, IDX(5));
+        set_prime(p, IDX(7));
 
         ushort sqrt_n = n > 4294836225 ? 0xffff : (ushort)sqrt(n);
         uint max_idx = lmmp_prime_cnt16_(sqrt_n);
         uint limit_idx = n >> 1;
 
-        for (ushort i = 1; i < max_idx; ++i) {
+        // 从质数 11 开始（下标 4）
+        for (ushort i = 4; i < max_idx; ++i) {
             uint prime = prime_short_table[i];
             uint start_idx = (prime * prime) >> 1;
             for (uint idx = start_idx; idx <= limit_idx; idx += prime) {
@@ -68,24 +132,35 @@ void lmmp_prime_int_table_init_(uint n) {
         }
         G.map = p;
     } else {
+        // 扩展部分（重分配）
         uint old_N = G.max;
         uint new_size = prime_table_size(n);
         G.map = REALLOC_TYPE(G.map, new_size, lmmp_bitset_t);
-        for (uint i = G.map_size; i < new_size; ++i) 
-            G.map[i] = LMMP_BITSET_MASK;
+
+        // 新块填充 wheel_mask
+        for (uint i = G.map_size, s = (G.map_size * 64) % 105; i < new_size; ++i) {
+            G.map[i] = wheel_mask[s];
+            s += LMMP_BITSET_BITS;
+            if (s >= 105)
+                s -= 105;
+        }
+
         G.map_size = new_size;
         G.max = n;
 
         lmmp_bitset_p restrict p = G.map;
+        set_not_prime(p, 0);
+        set_prime(p, IDX(3));
+        set_prime(p, IDX(5));
+        set_prime(p, IDX(7));
         uint limit_idx = (n - 1) >> 1;
         uint old_limit_idx = (old_N - 1) >> 1;
-
-        // set_not_prime(p, 0);
 
         ushort sqrt_n = n > 4294836225 ? 0xffff : (ushort)sqrt(n);
         uint max_idx = lmmp_prime_cnt16_(sqrt_n);
 
-        for (ushort i = 1; i < max_idx; ++i) {
+        // 从质数 11 开始
+        for (ushort i = 4; i < max_idx; ++i) {
             uint prime = prime_short_table[i];
             uint start = prime * prime;
             uint start_idx = start >> 1;
@@ -102,15 +177,18 @@ void lmmp_prime_int_table_init_(uint n) {
     }
 }
 
-bool lmmp_is_prime_table_(uint p) {
+#undef set_prime
+
+int lmmp_is_prime_table_(uint p) {
     if (p < PRIME_SHORT_TABLE_N) {
         ushort i = lmmp_prime_cnt16_(p);
         if (prime_short_table[i - 1] == p)
-            return true;
-        return false;
+            return 1;
+        return 0;
+    } else if (p > G.max) {
+        return -1;
     } else {
         // p>=3
-        lmmp_debug_assert(G.max >= p);
         lmmp_param_assert(p > 1);
         lmmp_param_assert((p & 1) == 1);
         uint idx = IDX(p);
@@ -121,7 +199,7 @@ bool lmmp_is_prime_table_(uint p) {
 void lmmp_prime_cache_init_(prime_cache_t* cache, uint n) {
     lmmp_param_assert(n > 2);
     lmmp_param_assert(n <= G.max);
-    cache->pp = ALLOC_TYPE(PRIME_CACHE_BLOCK_SIZE * PRIME_CACHE_BLOCK_NUM, uint);
+    cache->pp = ALLOC_TYPE(PRIME_CACHE_SIZE, uint);
     cache->size = 0;
     cache->start_idx = 0;
     uint max_bit_idx = (n - 1) / 2;

--- a/src/lammp/numth/is_prime_ulong.c
+++ b/src/lammp/numth/is_prime_ulong.c
@@ -257,13 +257,18 @@ static inline int miller_rabin_64(ulong a, ulong t, ulong u, ulong m, ulong m_in
  *******************************************************************************/
 
 bool lmmp_is_prime_uint_(uint n) {
-    if (n < PRIME_SHORT_TABLE_N) {
-        return lmmp_is_prime_table_(n);
-    }
-    if (n % 2 == 0)
+    if (n % 2 == 0 || n <= 1)
         return false;
+    int judge = lmmp_is_prime_table_(n);
+    if (judge == 0) {
+        return false;
+    } else if (judge == 1) {
+        return true;
+    }
+
     if (trial_div35711(n))
         return false;
+
     ushort bases[2];
     bases[0] = 2;
     bases[1] = dj_base49[((0x3AC69A35UL * n) & 0xFFFFFFFFUL) >> 21] + 3;
@@ -374,11 +379,14 @@ bool lmmp_is_prime_notrial_(ulong n) {
 }
 
 bool lmmp_is_prime_ulong_(ulong n) {
-    if (n < PRIME_SHORT_TABLE_N) {
-        return lmmp_is_prime_table_(n);
-    }
-    if (n % 2 == 0)
+    if (n % 2 == 0 || n <= 1)
         return false;
+    int judge = lmmp_is_prime_table_(n);
+    if (judge == 0) {
+        return false;
+    } else if (judge == 1) {
+        return true;
+    }
     if (trial_div35711(n))
         return false;
     return lmmp_is_prime_notrial_(n);


### PR DESCRIPTION
新的质数表通过使用预计算的3,5,7筛表来进行直接初始化，这产生了大约30%的性能提升：
<img width="869" height="748" alt="image" src="https://github.com/user-attachments/assets/dd4b0fb8-3b3a-4d71-9fdc-002ce47d469d" />
蓝色曲线为老旧实现，红色为本PR的实现，横坐标为筛选的质数表的范围，纵坐标为耗时（单位为微秒）
